### PR TITLE
do not track errors automatically

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -464,11 +464,13 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     }
 
     func onPlayerError(_ event: PlayerErrorEvent) {
-        trackError(errorCode: event.code.rawValue, errorMessage: event.message)
+        // we are tracking errors manually in the bitmovin player
+        // trackError(errorCode: event.code.rawValue, errorMessage: event.message)
     }
 
     func onSourceError(_ event: SourceErrorEvent) {
-        trackError(errorCode: event.code.rawValue, errorMessage: event.message)
+        // we are tracking errors manually in the bitmovin player
+        // trackError(errorCode: event.code.rawValue, errorMessage: event.message)
     }
 
     func trackError(errorCode: Int, errorMessage: String) {


### PR DESCRIPTION
PlayerError and SourceError are handled by the bitmovin player. trackError is also creating a new session if the current session has ended

### Problem
<!-- Describe the problem -->

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->

### Notes
<!-- Anything worth pointing out -->

### Checklist
- [ ] I added an update to `CHANGELOG.md` file
- [ ] I ran all the tests in the project and they succeed
